### PR TITLE
Bug Fix: Commit status context

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
       - name: Update deployment board with Defaults
         id: defaults
         continue-on-error: true                                      # Setting to true so the job doesn't fail if updating the board fails.
-        uses: im-open/create-github-deployment@v1.0.0                # You may also reference just the major or major.minor version
+        uses: im-open/create-github-deployment@v1.0.1                # You may also reference just the major or major.minor version
         with:
           workflow-actor: ${{ github.actor }}                        # This will add the user who kicked off the workflow to the deployment payload
           token: ${{ secrets.GITHUB_TOKEN }}                         # If a different token is used, update github-login with the corresponding account

--- a/dist/index.js
+++ b/dist/index.js
@@ -39566,6 +39566,7 @@ var require_deployments = __commonJS({
           environment: context.environment,
           task: WORKFLOW_DEPLOY,
           auto_merge: false,
+          required_contexts: [],
           payload: {
             entity: context.entity,
             instance: context.instance,

--- a/src/deployments.js
+++ b/src/deployments.js
@@ -82,6 +82,7 @@ async function createDeployment(context) {
       environment: context.environment,
       task: WORKFLOW_DEPLOY,
       auto_merge: false,
+      required_contexts: [],
 
       payload: {
         entity: context.entity,


### PR DESCRIPTION
A bug occurred that kept the deployment from being created because of repo contexts.

Added `deployment.required_contexts = []` to remove the requirements allowing the deployment to be created.